### PR TITLE
Add public_key output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ module "default" {
 
 ## Outputs
 
-| Name                  | Description               |
-|:----------------------|:--------------------------|
-| `key_name`            | Name of SSH key           |
+| Name                  | Description                                   |
+|:----------------------|:----------------------------------------------|
+| `key_name`            | Name of SSH key                               |
+| `public_key`          | Contents of the generated public key          |

--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,7 @@
 output "key_name" {
   value = "${element(compact(concat(aws_key_pair.imported.*.key_name, aws_key_pair.generated.*.key_name)), 0)}"
 }
+
+output "public_key" {
+  value = "${join("", tls_private_key.default.*.public_key_openssh)}"
+}


### PR DESCRIPTION
## what

* Add `public_key` output

## why

* We need an SSH public key string for adding it to a templates