### PR TITLE
 Added ability to create SSH key pair without importing the key pair to AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-aws-key-pair [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-key-pair.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-key-pair)
 
-Terraform module for generating or importing an SSH public key file into AWS.
+Terraform module for generating an SSH public key file.
 
 ## Usage
 
@@ -11,12 +11,9 @@ module "ssh_key_pair" {
   stage                 = "prod"
   name                  = "app"
   ssh_public_key_path   = "/secrets"
-  generate_ssh_key      = "true"
   private_key_extension = ".pem"
   public_key_extension  = ".pub"
   chmod_command         = "chmod 600 %v"
-  region                = "us-east-1"
-  import_key_pair       = "true"
 }
 ```
 
@@ -29,12 +26,9 @@ module "ssh_key_pair" {
 | `stage`                      | ``             | Stage (e.g. `prod`, `dev`, `staging`)                    | Yes       |
 | `name`                       | ``             | Application or solution name  (e.g. `app`)               | Yes       |
 | `ssh_public_key_path`        | ``             | Path to SSH public key directory (e.g. `/secrets`)       | Yes       |
-| `generate_ssh_key`           | `false`        | If set to `true`, new SSH key pair will be created       | No        |
 | `private_key_extension`      | ``             | Private key file extension (_e.g._ `.pem`)               | No        |
 | `public_key_extension`       | `.pub`         | Public key file extension (_e.g._ `.pub`)                | No        |
 | `chmod_command`              | `chmod 600 %v` | Template of the command executed on the private key file | Yes(Linux), No(Windows) |
-| `region`                     | `us-east-1`    | Region for AWS provider                                  | No        |
-| `import_key_pair`            | `true`         | If set to `false`, new SSH key pair will be created without importing the key pair into the AWS | No        |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ module "ssh_key_pair" {
   private_key_extension = ".pem"
   public_key_extension  = ".pub"
   chmod_command         = "chmod 600 %v"
+  region                = "us-east-1"
+  import_key_pair       = "true"
 }
 ```
 
@@ -31,7 +33,8 @@ module "ssh_key_pair" {
 | `private_key_extension`      | ``             | Private key file extension (_e.g._ `.pem`)               | No        |
 | `public_key_extension`       | `.pub`         | Public key file extension (_e.g._ `.pub`)                | No        |
 | `chmod_command`              | `chmod 600 %v` | Template of the command executed on the private key file | Yes(Linux), No(Windows) |
-
+| `region`                     | `us-east-1`    | Region for AWS provider                                  | No        |
+| `import_key_pair`            | `true`         | If set to `false`, new SSH key pair will be created without importing the key pair into the AWS | No        |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,8 @@
+provider "aws" {
+  region      = "${var.region}"
+  version = "~> 1.8"
+}
+
 module "label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
   namespace  = "${var.namespace}"
@@ -14,7 +19,7 @@ locals {
 }
 
 resource "aws_key_pair" "imported" {
-  count      = "${var.generate_ssh_key == "false" ? 1 : 0}"
+  count      = "${var.generate_ssh_key == "false" && var.only_generate_ssh_key == "false" ? 1 : 0}"
   key_name   = "${module.label.id}"
   public_key = "${file("${local.public_key_filename}")}"
 }
@@ -25,7 +30,7 @@ resource "tls_private_key" "default" {
 }
 
 resource "aws_key_pair" "generated" {
-  count      = "${var.generate_ssh_key == "true" ? 1 : 0}"
+  count      = "${var.generate_ssh_key == "true" && var.only_generate_ssh_key == "false" ? 1 : 0}"
   depends_on = ["tls_private_key.default"]
   key_name   = "${module.label.id}"
   public_key = "${tls_private_key.default.public_key_openssh}"

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,3 @@
-provider "aws" {
-  region      = "${var.region}"
-  version = "~> 1.8"
-}
-
 module "label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
   namespace  = "${var.namespace}"
@@ -18,40 +13,24 @@ locals {
   private_key_filename = "${var.ssh_public_key_path}/${module.label.id}${var.private_key_extension}"
 }
 
-resource "aws_key_pair" "imported" {
-  count      = "${var.generate_ssh_key == "false" && var.import_key_pair == "false" ? 1 : 0}"
-  key_name   = "${module.label.id}"
-  public_key = "${file("${local.public_key_filename}")}"
-}
-
 resource "tls_private_key" "default" {
-  count     = "${var.generate_ssh_key == "true" ? 1 : 0}"
   algorithm = "${var.ssh_key_algorithm}"
 }
 
-resource "aws_key_pair" "generated" {
-  count      = "${var.generate_ssh_key == "true" && var.import_key_pair == "false" ? 1 : 0}"
-  depends_on = ["tls_private_key.default"]
-  key_name   = "${module.label.id}"
-  public_key = "${tls_private_key.default.public_key_openssh}"
-}
-
 resource "local_file" "public_key_openssh" {
-  count      = "${var.generate_ssh_key == "true" ? 1 : 0}"
   depends_on = ["tls_private_key.default"]
   content    = "${tls_private_key.default.public_key_openssh}"
   filename   = "${local.public_key_filename}"
 }
 
 resource "local_file" "private_key_pem" {
-  count      = "${var.generate_ssh_key == "true" ? 1 : 0}"
   depends_on = ["tls_private_key.default"]
   content    = "${tls_private_key.default.private_key_pem}"
   filename   = "${local.private_key_filename}"
 }
 
 resource "null_resource" "chmod" {
-  count      = "${var.generate_ssh_key == "true" && var.chmod_command != "" ? 1 : 0}"
+  count      = "${var.chmod_command != "" ? 1 : 0}"
   depends_on = ["local_file.private_key_pem"]
 
   provisioner "local-exec" {

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 resource "aws_key_pair" "imported" {
-  count      = "${var.generate_ssh_key == "false" && var.only_generate_ssh_key == "false" ? 1 : 0}"
+  count      = "${var.generate_ssh_key == "false" && var.import_key_pair == "false" ? 1 : 0}"
   key_name   = "${module.label.id}"
   public_key = "${file("${local.public_key_filename}")}"
 }
@@ -30,7 +30,7 @@ resource "tls_private_key" "default" {
 }
 
 resource "aws_key_pair" "generated" {
-  count      = "${var.generate_ssh_key == "true" && var.only_generate_ssh_key == "false" ? 1 : 0}"
+  count      = "${var.generate_ssh_key == "true" && var.import_key_pair == "false" ? 1 : 0}"
   depends_on = ["tls_private_key.default"]
   key_name   = "${module.label.id}"
   public_key = "${tls_private_key.default.public_key_openssh}"

--- a/output.tf
+++ b/output.tf
@@ -1,5 +1,5 @@
 output "key_name" {
-  value = "${element(compact(concat(list(module.label.id), aws_key_pair.imported.*.key_name, aws_key_pair.generated.*.key_name)), 0)}"
+  value = "${module.label.id}"
 }
 
 output "public_key" {

--- a/output.tf
+++ b/output.tf
@@ -1,5 +1,5 @@
 output "key_name" {
-  value = "${element(compact(concat(aws_key_pair.imported.*.key_name, aws_key_pair.generated.*.key_name)), 0)}"
+  value = "${element(compact(concat(list(module.label.id), aws_key_pair.imported.*.key_name, aws_key_pair.generated.*.key_name)), 0)}"
 }
 
 output "public_key" {

--- a/variables.tf
+++ b/variables.tf
@@ -64,3 +64,14 @@ variable "chmod_command" {
   default     = "chmod 600 %v"
   description = "Template of the command executed on the private key file"
 }
+
+variable "region" {
+  type        = "string"
+  default     = "us-east-1"
+}
+
+variable only_generate_ssh_key  {
+  type        = "string"
+  default     = "false"
+  description = "If set to `true`, new SSH key pair will be created without importing the key pair into the AWS"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -70,8 +70,8 @@ variable "region" {
   default     = "us-east-1"
 }
 
-variable only_generate_ssh_key  {
+variable import_key_pair  {
   type        = "string"
-  default     = "false"
-  description = "If set to `true`, new SSH key pair will be created without importing the key pair into the AWS"
+  default     = "true"
+  description = "If set to `false`, new SSH key pair will be created without importing the key pair into the AWS"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,11 +36,6 @@ variable "ssh_public_key_path" {
   description = "Path to SSH public key directory (e.g. `/secrets`)"
 }
 
-variable "generate_ssh_key" {
-  default     = "false"
-  description = "If set to `true`, new SSH key pair will be created"
-}
-
 variable "ssh_key_algorithm" {
   type        = "string"
   default     = "RSA"
@@ -63,15 +58,4 @@ variable "chmod_command" {
   type        = "string"
   default     = "chmod 600 %v"
   description = "Template of the command executed on the private key file"
-}
-
-variable "region" {
-  type        = "string"
-  default     = "us-east-1"
-}
-
-variable import_key_pair  {
-  type        = "string"
-  default     = "true"
-  description = "If set to `false`, new SSH key pair will be created without importing the key pair into the AWS"
 }


### PR DESCRIPTION
## what
* Now it is possible to generate key pair, for example, to work with Google Cloud

## why
* To work with other providers (albeit probably a better idea to create a new module!)