### PR TITLE
Add option to NOT generate or import SSH key

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ module "ssh_key_pair" {
 | `name`                       | ``             | Application or solution name  (e.g. `app`)               | Yes       |
 | `ssh_public_key_path`        | ``             | Path to SSH public key directory (e.g. `/secrets`)       | Yes       |
 | `generate_ssh_key`           | `false`        | If set to `true`, new SSH key pair will be created       | No        |
+| `import_ssh_key`             | `false`        | If set to `true`, existing SSH public key will be imported from `ssh_public_key_path` using the `null_resource` name format      | No        |
 | `private_key_extension`      | ``             | Private key file extension (_e.g._ `.pem`)               | No        |
 | `public_key_extension`       | `.pub`         | Public key file extension (_e.g._ `.pub`)                | No        |
 | `chmod_command`              | `chmod 600 %v` | Template of the command executed on the private key file | Yes(Linux), No(Windows) |

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.5"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"
@@ -13,8 +13,13 @@ locals {
   private_key_filename = "${var.ssh_public_key_path}/${module.label.id}${var.private_key_extension}"
 }
 
+resource "null_resource" "import or generate key" {
+  count                                                                     = "${var.generate_ssh_key == "true" && var.import_ssh_key == "true" ? 1 : 0}"
+  "You cannot generate and import a key, you can only do one or the other." = true
+}
+
 resource "aws_key_pair" "imported" {
-  count      = "${var.generate_ssh_key == "false" ? 1 : 0}"
+  count      = "${var.import_ssh_key == "true" ? 1 : 0}"
   key_name   = "${module.label.id}"
   public_key = "${file("${local.public_key_filename}")}"
 }

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ locals {
 }
 
 resource "null_resource" "ASSERTION_FAILED" {
-  count = "${var.generate_ssh_key == "true" && var.import_ssh_key == "true" ? 1 : 0}"
+  count                                                                     = "${var.generate_ssh_key == "true" && var.import_ssh_key == "true" ? 1 : 0}"
   "You cannot generate AND import a key, you can only do one or the other." = true
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.5"
+  source     = "git::https://github.com/cloudposse/terraform-terraform-label.git?ref=tags/0.1.2"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"

--- a/main.tf
+++ b/main.tf
@@ -13,9 +13,9 @@ locals {
   private_key_filename = "${var.ssh_public_key_path}/${module.label.id}${var.private_key_extension}"
 }
 
-resource "null_resource" "import or generate key" {
-  count                                                                     = "${var.generate_ssh_key == "true" && var.import_ssh_key == "true" ? 1 : 0}"
-  "You cannot generate and import a key, you can only do one or the other." = true
+resource "null_resource" "ASSERTION_FAILED" {
+  count = "${var.generate_ssh_key == "true" && var.import_ssh_key == "true" ? 1 : 0}"
+  "You cannot generate AND import a key, you can only do one or the other." = true
 }
 
 resource "aws_key_pair" "imported" {

--- a/output.tf
+++ b/output.tf
@@ -1,5 +1,5 @@
 output "key_name" {
-  value = "${element(compact(concat(aws_key_pair.imported.*.key_name, aws_key_pair.generated.*.key_name)), 0)}"
+  value = "${element(concat(compact(concat(aws_key_pair.imported.*.key_name, aws_key_pair.generated.*.key_name)), list("")), 0)}"
 }
 
 output "public_key" {

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,11 @@ variable "generate_ssh_key" {
   description = "If set to `true`, new SSH key pair will be created"
 }
 
+variable "import_ssh_key" {
+  default     = "false"
+  description = "If set to `true`, existing SSH public key will be imported from `ssh_public_key_path` using the `null_resource` name format"
+}
+
 variable "ssh_key_algorithm" {
   type        = "string"
   default     = "RSA"


### PR DESCRIPTION
## what 
* Added `import_ssh_key` variable.
* Add conditional check for if import and generate are both used it gives error message.
* Fixed errors that happen when import and generate values are both false

## why
* Generate added option to use module without generating or importing a key
