### PR TITLE
Fixes issue with null public_key_filename.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,8 +9,8 @@ module "label" {
 }
 
 locals {
-  public_key_filename  = "${var.generate_ssh_key == "true" ? format("%s/%s%s", var.ssh_public_key_path, module.label.id, var.public_key_extension) : ""}"
-  private_key_filename = "${var.generate_ssh_key == "true" ? format("%s/%s%s", var.ssh_public_key_path, module.label.id, var.private_key_extension) : ""}"
+  public_key_filename  = "${format("%s/%s%s", var.ssh_public_key_path, module.label.id, var.public_key_extension)}"
+  private_key_filename = "${format("%s/%s%s", var.ssh_public_key_path, module.label.id, var.private_key_extension)}"
 }
 
 resource "aws_key_pair" "imported" {


### PR DESCRIPTION
If generate_ssh_key is false, line 19 fails because public_key_filename has not been set. Solution always sets local vars and allows value of generate_ssh_key to determine usage.