### PR TITLE
Add a `private_key` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Available targets:
 | Name | Description |
 |------|-------------|
 | key_name | Name of SSH key |
+| private_key | Content of the generated private key |
 | private_key_filename | Private Key Filename |
 | public_key | Content of the generated public key |
 | public_key_filename | Public Key Filename |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -21,6 +21,7 @@
 | Name | Description |
 |------|-------------|
 | key_name | Name of SSH key |
+| private_key | Content of the generated private key |
 | private_key_filename | Private Key Filename |
 | public_key | Content of the generated public key |
 | public_key_filename | Public Key Filename |

--- a/outputs.tf
+++ b/outputs.tf
@@ -12,6 +12,12 @@ output "public_key" {
   description = "Content of the generated public key"
 }
 
+output "private_key" {
+  sensitive   = true
+  description = "Content of the generated private key"
+  value       = join("", tls_private_key.default.*.private_key_pem)
+}
+
 output "public_key_filename" {
   description = "Public Key Filename"
   value       = local.public_key_filename


### PR DESCRIPTION
Sometimes it's useful to have this available -- e.g. for CI situations
in which one needs to create a scratch key, create an instance, then
provision the instance using the newly-created keypair.