### PR TITLE
Allow import of ssh public key with arbitrary name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 [![Cloud Posse][logo]](https://cpco.io/homepage)
 
-# terraform-aws-key-pair [![Codefresh Build Status](https://g.codefresh.io/api/badges/pipeline/cloudposse/terraform-modules%2Fterraform-aws-key-pair?type=cf-1)](https://g.codefresh.io/public/accounts/cloudposse/pipelines/5d1bbbe8c765737a2ad1e5a8) [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-key-pair.svg)](https://github.com/cloudposse/terraform-aws-key-pair/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+# terraform-aws-key-pair [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-key-pair.svg)](https://github.com/cloudposse/terraform-aws-key-pair/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 
 
 Terraform module for generating or importing an SSH public key file into AWS.
@@ -139,12 +139,13 @@ Available targets:
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
-| generate\_ssh\_key | If set to `true`, new SSH key pair will be created | `bool` | `false` | no |
+| generate\_ssh\_key | If set to `true`, new SSH key pair will be created and `ssh_public_key_file` will be ignored | `bool` | `false` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `""` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
 | private\_key\_extension | Private key extension | `string` | `""` | no |
 | public\_key\_extension | Public key extension | `string` | `".pub"` | no |
 | ssh\_key\_algorithm | SSH key algorithm | `string` | `"RSA"` | no |
+| ssh\_public\_key\_file | Name of existing SSH public key file (e.g. `id_rsa.pub`) | `string` | `null` | no |
 | ssh\_public\_key\_path | Path to SSH public key directory (e.g. `/secrets`) | `string` | n/a | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `""` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -23,12 +23,13 @@
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
-| generate\_ssh\_key | If set to `true`, new SSH key pair will be created | `bool` | `false` | no |
+| generate\_ssh\_key | If set to `true`, new SSH key pair will be created and `ssh_public_key_file` will be ignored | `bool` | `false` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `""` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `""` | no |
 | private\_key\_extension | Private key extension | `string` | `""` | no |
 | public\_key\_extension | Public key extension | `string` | `".pub"` | no |
 | ssh\_key\_algorithm | SSH key algorithm | `string` | `"RSA"` | no |
+| ssh\_public\_key\_file | Name of existing SSH public key file (e.g. `id_rsa.pub`) | `string` | `null` | no |
 | ssh\_public\_key\_path | Path to SSH public key directory (e.g. `/secrets`) | `string` | n/a | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `""` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -1,4 +1,4 @@
-region = "us-west-1"
+region = "us-east-2"
 
 namespace = "eg"
 
@@ -6,6 +6,6 @@ stage = "test"
 
 name = "aws-key-pair"
 
-ssh_public_key_path = "/secrets"
+ssh_public_key_path = "/tmp/secrets"
 
 generate_ssh_key = true

--- a/examples/import-key/fixtures.us-east-2.tfvars
+++ b/examples/import-key/fixtures.us-east-2.tfvars
@@ -1,0 +1,13 @@
+region = "us-east-2"
+
+namespace = "eg"
+
+stage = "test"
+
+name = "aws-key-pair"
+
+ssh_public_key_path = "/tmp/secrets"
+
+ssh_public_key_file = "id_rsa_test.pub"
+
+generate_ssh_key = false

--- a/examples/import-key/main.tf
+++ b/examples/import-key/main.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  region = var.region
+}
+
+module "aws_key_pair" {
+  source              = "../../"
+  namespace           = var.namespace
+  stage               = var.stage
+  name                = var.name
+  ssh_public_key_path = var.ssh_public_key_path
+  ssh_public_key_file = var.ssh_public_key_file
+  generate_ssh_key    = var.generate_ssh_key
+}

--- a/examples/import-key/outputs.tf
+++ b/examples/import-key/outputs.tf
@@ -1,0 +1,19 @@
+output "key_name" {
+  value       = module.aws_key_pair.key_name
+  description = "Name of SSH key"
+}
+
+output "public_key" {
+  value       = module.aws_key_pair.public_key
+  description = "Content of the imported public key"
+}
+
+output "public_key_filename" {
+  description = "Public Key Filename"
+  value       = module.aws_key_pair.public_key_filename
+}
+
+output "private_key_filename" {
+  description = "Private Key Filename"
+  value       = module.aws_key_pair.private_key_filename
+}

--- a/examples/import-key/variables.tf
+++ b/examples/import-key/variables.tf
@@ -1,0 +1,34 @@
+variable "region" {
+  type        = string
+  description = "AWS region"
+}
+
+variable "namespace" {
+  type        = string
+  description = "Namespace (e.g. `eg` or `cp`)"
+}
+
+variable "stage" {
+  type        = string
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+}
+
+variable "name" {
+  type        = string
+  description = "Application or solution name (e.g. `app`)"
+}
+
+variable "ssh_public_key_path" {
+  type        = string
+  description = "Path to SSH public key directory (e.g. `/secrets`)"
+}
+
+variable "ssh_public_key_file" {
+  type        = string
+  description = "Name of existing SSH public key file (e.g. `id_rsa.pub`)"
+}
+
+variable "generate_ssh_key" {
+  type        = bool
+  description = "If set to `true`, new SSH key pair will be created"
+}

--- a/main.tf
+++ b/main.tf
@@ -11,10 +11,9 @@ module "label" {
 
 locals {
   public_key_filename = format(
-    "%s/%s%s",
+    "%s/%s",
     var.ssh_public_key_path,
-    module.label.id,
-    var.public_key_extension
+    coalesce(var.ssh_public_key_file, join("", [module.label.id, var.public_key_extension]))
   )
 
   private_key_filename = format(

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,7 +8,7 @@ output "key_name" {
 }
 
 output "public_key" {
-  value       = join("", tls_private_key.default.*.public_key_openssh)
+  value       = coalesce(join("", aws_key_pair.imported.*.public_key), join("", tls_private_key.default.*.public_key_openssh))
   description = "Content of the generated public key"
 }
 

--- a/test/src/Gopkg.lock
+++ b/test/src/Gopkg.lock
@@ -85,6 +85,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/gruntwork-io/terratest/modules/ssh",
     "github.com/gruntwork-io/terratest/modules/terraform",
     "github.com/stretchr/testify/assert",
   ]

--- a/test/src/Makefile
+++ b/test/src/Makefile
@@ -42,7 +42,8 @@ init: $(BASE)/vendor
 .PHONY : test
 ## Run tests
 test: init
-	cd $(BASE) && go test -v -timeout 30m -run TestExamplesComplete
+	cd $(BASE) && go test -v -timeout 30m -run TestExamplesComplete &&\
+		go test -v -timeout 30m -run TestImportKey
 
 .PHONY : clean
 ## Clean up files

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -16,7 +16,7 @@ func TestExamplesComplete(t *testing.T) {
 		TerraformDir: "../../examples/complete",
 		Upgrade:      true,
 		// Variables to pass to our Terraform code using -var-file options
-		VarFiles: []string{"fixtures.us-west-1.tfvars"},
+		VarFiles: []string{"fixtures.us-east-2.tfvars"},
 	}
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created

--- a/test/src/examples_import_key_test.go
+++ b/test/src/examples_import_key_test.go
@@ -1,0 +1,61 @@
+package test
+
+import (
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/ssh"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test the Terraform module in examples/complete using Terratest.
+func TestImportKey(t *testing.T) {
+	t.Parallel()
+
+	terraformOptions := &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: "../../examples/import-key",
+		Upgrade:      true,
+		// Variables to pass to our Terraform code using -var-file options
+		VarFiles: []string{"fixtures.us-east-2.tfvars"},
+	}
+
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer terraform.Destroy(t, terraformOptions)
+
+	// Create dummy SSH key and write to file
+	keyPair, err := ssh.GenerateRSAKeyPairE(t, 2048)
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	err = ioutil.WriteFile("/tmp/secrets/id_rsa_test.pub", []byte(keyPair.PublicKey), 0600)
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
+
+	// Verify `key_name` output is as expected
+	keyName := terraform.Output(t, terraformOptions, "key_name")
+
+	expectedKeyName := "eg-test-aws-key-pair"
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, expectedKeyName, keyName)
+
+	// Verify `public_key` output is as expected
+	publicKey := terraform.Output(t, terraformOptions, "public_key")
+
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, strings.TrimSuffix(keyPair.PublicKey, "\n"), publicKey)
+
+	// Verify `public_key_filename` output is as expected
+	publicKeyFileName := terraform.Output(t, terraformOptions, "public_key_filename")
+
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, "/tmp/secrets/id_rsa_test.pub", publicKeyFileName)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -45,10 +45,16 @@ variable "ssh_public_key_path" {
   description = "Path to SSH public key directory (e.g. `/secrets`)"
 }
 
+variable "ssh_public_key_file" {
+  type        = string
+  description = "Name of existing SSH public key file (e.g. `id_rsa.pub`)"
+  default     = null
+}
+
 variable "generate_ssh_key" {
   type        = bool
   default     = false
-  description = "If set to `true`, new SSH key pair will be created"
+  description = "If set to `true`, new SSH key pair will be created and `ssh_public_key_file` will be ignored"
 }
 
 variable "ssh_key_algorithm" {


### PR DESCRIPTION
## what
* Allow import of existing ssh public key with arbitrary filename
* Updated tests to use us-east-2
* Added test for import existing public key file

## why
* existing functionality assumes name of key file

## references
* None

