### PR TITLE
Add support for tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -142,6 +143,7 @@ Available targets:
 | public\_key | Content of the generated public key |
 | public\_key\_filename | Public Key Filename |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -44,3 +45,4 @@
 | public\_key | Content of the generated public key |
 | public\_key\_filename | Public Key Filename |
 
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,7 @@ resource "aws_key_pair" "imported" {
   count      = var.generate_ssh_key == false ? 1 : 0
   key_name   = module.label.id
   public_key = file(local.public_key_filename)
+  tags = module.label.tags
 }
 
 resource "tls_private_key" "default" {
@@ -40,6 +41,7 @@ resource "aws_key_pair" "generated" {
   depends_on = [tls_private_key.default]
   key_name   = module.label.id
   public_key = tls_private_key.default[0].public_key_openssh
+  tags = module.label.tags
 }
 
 resource "local_file" "public_key_openssh" {

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "aws_key_pair" "imported" {
   count      = var.generate_ssh_key == false ? 1 : 0
   key_name   = module.label.id
   public_key = file(local.public_key_filename)
-  tags = module.label.tags
+  tags       = module.label.tags
 }
 
 resource "tls_private_key" "default" {
@@ -41,7 +41,7 @@ resource "aws_key_pair" "generated" {
   depends_on = [tls_private_key.default]
   key_name   = module.label.id
   public_key = tls_private_key.default[0].public_key_openssh
-  tags = module.label.tags
+  tags       = module.label.tags
 }
 
 resource "local_file" "public_key_openssh" {


### PR DESCRIPTION
## what
* Add tags population to aws_key_pair that are already using the variable 

## why
* For billing to be able to filter resources by tag
* Requirements within a company to tag all resources that support tags

