### PR TITLE
feat(aws-key-pair): enable the ssm parameter store to record the key-pair distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,6 @@ We highly recommend that in your code you pin the version to the exact version y
 using so that your infrastructure remains stable, and update versions in a
 systematic way so that they do not catch you by surprise.
 
-Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
-the registry shows many of our inputs as required when in fact they are optional.
-The table below correctly indicates which inputs are required.
-
 
 ```hcl
 module "ssh_key_pair" {
@@ -156,6 +152,7 @@ Available targets:
 |------|------|
 | [aws_key_pair.generated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_key_pair.imported](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
+| [aws_ssm_parameter.private_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [local_file.public_key_openssh](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_sensitive_file.private_key_pem](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file) | resource |
 | [tls_private_key.default](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
@@ -185,6 +182,8 @@ Available targets:
 | <a name="input_ssh_key_algorithm"></a> [ssh\_key\_algorithm](#input\_ssh\_key\_algorithm) | SSH key algorithm | `string` | `"RSA"` | no |
 | <a name="input_ssh_public_key_file"></a> [ssh\_public\_key\_file](#input\_ssh\_public\_key\_file) | Name of existing SSH public key file (e.g. `id_rsa.pub`) | `string` | `null` | no |
 | <a name="input_ssh_public_key_path"></a> [ssh\_public\_key\_path](#input\_ssh\_public\_key\_path) | Path to SSH public key directory (e.g. `/secrets`) | `string` | n/a | yes |
+| <a name="input_ssm_parameter_enabled"></a> [ssm\_parameter\_enabled](#input\_ssm\_parameter\_enabled) | Whether an SSM parameter store value is created to store the key's private key pem. | `bool` | `false` | no |
+| <a name="input_ssm_parameter_path_prefix"></a> [ssm\_parameter\_path\_prefix](#input\_ssm\_parameter\_path\_prefix) | The path prefix for the created SSM parameter e.g. '/ec2/key-pairs/acme-ue1-dev-bastion'. `ssm_parameter_enabled` must be set to `true` for this to take affect. | `string` | `"/ec2/key-pairs/"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -29,6 +29,7 @@
 |------|------|
 | [aws_key_pair.generated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_key_pair.imported](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
+| [aws_ssm_parameter.private_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [local_file.public_key_openssh](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_sensitive_file.private_key_pem](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file) | resource |
 | [tls_private_key.default](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
@@ -58,6 +59,8 @@
 | <a name="input_ssh_key_algorithm"></a> [ssh\_key\_algorithm](#input\_ssh\_key\_algorithm) | SSH key algorithm | `string` | `"RSA"` | no |
 | <a name="input_ssh_public_key_file"></a> [ssh\_public\_key\_file](#input\_ssh\_public\_key\_file) | Name of existing SSH public key file (e.g. `id_rsa.pub`) | `string` | `null` | no |
 | <a name="input_ssh_public_key_path"></a> [ssh\_public\_key\_path](#input\_ssh\_public\_key\_path) | Path to SSH public key directory (e.g. `/secrets`) | `string` | n/a | yes |
+| <a name="input_ssm_parameter_enabled"></a> [ssm\_parameter\_enabled](#input\_ssm\_parameter\_enabled) | Whether an SSM parameter store value is created to store the key's private key pem. | `bool` | `false` | no |
+| <a name="input_ssm_parameter_path_prefix"></a> [ssm\_parameter\_path\_prefix](#input\_ssm\_parameter\_path\_prefix) | The path prefix for the created SSM parameter e.g. '/ec2/key-pairs/acme-ue1-dev-bastion'. `ssm_parameter_enabled` must be set to `true` for this to take affect. | `string` | `"/ec2/key-pairs/"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -50,9 +50,9 @@ resource "local_sensitive_file" "private_key_pem" {
 }
 
 resource "aws_ssm_parameter" "private_key" {
-  count = local.enabled && var.ssm_parameter_enabled == true ? 1 : 0
+  count = local.enabled && var. generate_ssh_key && var.ssm_parameter_enabled == true ? 1 : 0
   name  = format("%s%s", var.ssm_parameter_path_prefix, module.this.id)
   type  = "SecureString"
-  value = tls_private_key.default.private_key_pem
+  value = tls_private_key.default[0].private_key_pem
   tags  = module.this.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -48,3 +48,11 @@ resource "local_sensitive_file" "private_key_pem" {
   filename        = local.private_key_filename
   file_permission = "0600"
 }
+
+resource "aws_ssm_parameter" "private_key" {
+  count = local.enabled && var.ssm_parameter_enabled == true ? 1 : 0
+  name  = format("%s/%s", var.ssm_parameter_path_prefix, module.this.id)
+  type  = "SecureString"
+  value = tls_private_key.default.private_key_pem
+  tags  = module.this.tags
+}

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "local_sensitive_file" "private_key_pem" {
 
 resource "aws_ssm_parameter" "private_key" {
   count = local.enabled && var.ssm_parameter_enabled == true ? 1 : 0
-  name  = format("%s/%s", var.ssm_parameter_path_prefix, module.this.id)
+  name  = format("%s%s", var.ssm_parameter_path_prefix, module.this.id)
   type  = "SecureString"
   value = tls_private_key.default.private_key_pem
   tags  = module.this.tags

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ resource "local_sensitive_file" "private_key_pem" {
 }
 
 resource "aws_ssm_parameter" "private_key" {
-  count = local.enabled && var. generate_ssh_key && var.ssm_parameter_enabled == true ? 1 : 0
+  count = local.enabled && var.generate_ssh_key && var.ssm_parameter_enabled == true ? 1 : 0
   name  = format("%s%s", var.ssm_parameter_path_prefix, module.this.id)
   type  = "SecureString"
   value = tls_private_key.default[0].private_key_pem

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "public_key_extension" {
 variable "ssm_parameter_enabled" {
   type        = bool
   default     = false
-  description = "Whether an SSM parameter store value is created to store the key's private key pem."  
+  description = "Whether an SSM parameter store value is created to store the key's private key pem."
 }
 
 variable "ssm_parameter_path_prefix" {

--- a/variables.tf
+++ b/variables.tf
@@ -32,3 +32,15 @@ variable "public_key_extension" {
   default     = ".pub"
   description = "Public key extension"
 }
+
+variable "ssm_parameter_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether an SSM parameter store value is created to store the key's private key pem."  
+}
+
+variable "ssm_parameter_path_prefix" {
+  type        = string
+  default     = "/ec2/key-pairs/"
+  description = "The path prefix for the created SSM parameter e.g. '/ec2/key-pairs/acme-ue1-dev-bastion'. `ssm_parameter_enabled` must be set to `true` for this to take affect."
+}


### PR DESCRIPTION
## what

In this PR, we can use the [AWS SSM Parameter store resource](https://registry.terraform.io/providers/rgeraskin/aws3/latest/docs/resources/ssm_parameter) to facilitate the secure management of private key information. This resource allows us to gather the private key information generated by the current module and securely store it in the parameter store.

## why

The objective behind this enhancement is to ensure the secure distribution of private key ownership within the AWS infrastructure. We can centrally manage and protect sensitive information, increasing operational efficiency and reducing the likelihood of unauthorized access to critical resources.

## references

_No issue relates to current improvement._
<br/>I have run these required commands, 
`make init` 
`make readme`

Kindly review this PR for module improvements. Thank you